### PR TITLE
Middleware of specter should bypass errors object to error middleware of express.

### DIFF
--- a/packages/specter/lib/specter.js
+++ b/packages/specter/lib/specter.js
@@ -58,9 +58,7 @@ class Specter {
                 }
             }
             catch (e) {
-                console.error(e);
-                res.status(500);
-                res.send(e);
+                next(e);
             }
             return;
         };

--- a/packages/specter/src/specter.ts
+++ b/packages/specter/src/specter.ts
@@ -70,9 +70,7 @@ export default class Specter {
           res.end(null);
         }
       } catch (e) {
-        console.error(e);
-        res.status(500);
-        res.send(e);
+        next(e);
       }
       return;
     };


### PR DESCRIPTION
# About
- specter middleware handling **all** errors in thrown self.
- I want to handled an error the specter with express middleware.

# Example

```
  server.use('/xhr', Specter.createMiddleware({}))
  server.use(errorHandler)  /* errorHandler as (err, req, res, next) => ... */
```