### PR TITLE
Fix: Failed to execute 'fetch' on 'Window' Illegal invocation.

### DIFF
--- a/packages/client/lib/browser/client.js
+++ b/packages/client/lib/browser/client.js
@@ -53,6 +53,9 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var response_1 = __importDefault(require("./response"));
 var querystring_1 = require("querystring");
 var unfetch_1 = __importDefault(require("unfetch"));
+// refs: https://github.com/developit/unfetch/issues/46
+// refs: https://github.com/developit/unfetch/issues/46#issuecomment-552492844
+var fetch = unfetch_1.default.bind(window);
 var DefaultContentType = "application/json; charset=utf-8";
 var SpecterClient = /** @class */ (function () {
     function SpecterClient(options) {
@@ -77,7 +80,13 @@ var SpecterClient = /** @class */ (function () {
                         if (body && !head["Content-Type"]) {
                             head["Content-Type"] = DefaultContentType;
                         }
-                        return [4 /*yield*/, unfetch_1.default(path, __assign({ method: method, headers: head, body: body }, this.fetchOptions))];
+                        return [4 /*yield*/, (method === "GET" || method === "HEAD"
+                                ? fetch(path, __assign({ method: method, headers: head }, this.fetchOptions))
+                                : fetch(path, {
+                                    method: method,
+                                    headers: head,
+                                    body: body
+                                }))];
                     case 1:
                         response = _c.sent();
                         return [4 /*yield*/, response.json()];
@@ -140,7 +149,7 @@ var SpecterClient = /** @class */ (function () {
                 switch (_a.label) {
                     case 0:
                         path = this.createPath(request);
-                        return [4 /*yield*/, unfetch_1.default(path, __assign({ method: "HEAD", headers: request.headers, body: JSON.stringify(request.body) }, this.fetchOptions))];
+                        return [4 /*yield*/, fetch(path, __assign({ method: "HEAD", headers: request.headers, body: JSON.stringify(request.body) }, this.fetchOptions))];
                     case 1:
                         response = _a.sent();
                         return [2 /*return*/, response.ok];

--- a/packages/client/src/browser/client.ts
+++ b/packages/client/src/browser/client.ts
@@ -1,8 +1,11 @@
 import SpecterRequest from "./request";
 import SpecterResponse from "./response";
 import { stringify } from "querystring";
-import { pathToFileURL } from "url";
-import fetch from "unfetch";
+import xfetch from "unfetch";
+
+// refs: https://github.com/developit/unfetch/issues/46
+// refs: https://github.com/developit/unfetch/issues/46#issuecomment-552492844
+const fetch = xfetch.bind(window);
 
 type DefaultRequest = SpecterRequest<any, any, any>;
 type DefaultResponse = SpecterResponse<any, any>;
@@ -34,12 +37,17 @@ export default class SpecterClient {
     if (body && !head["Content-Type"]) {
       head["Content-Type"] = DefaultContentType;
     }
-    const response = await fetch(path, {
-      method,
-      headers: head,
-      body,
-      ...this.fetchOptions
-    });
+    const response = await (method === "GET" || method === "HEAD"
+      ? fetch(path, {
+          method,
+          headers: head,
+          ...this.fetchOptions
+        })
+      : fetch(path, {
+          method,
+          headers: head,
+          body
+        }));
 
     const json = await response.json();
     const h = response.headers as Headers & {


### PR DESCRIPTION
# Kind modules

- @specter/client/lib/browser

# About

## 1. Failed to execute 'fetch' on 'Window' Illegal invocation.

![Failed to execute 'fetch' on 'Window' Illegal invocation.](https://user-images.githubusercontent.com/9594376/68755612-1fdbc880-064c-11ea-88d2-04decd353108.png)

- Cause exception in browser when unfetch using with webpack, typescript. babel and other compiler.
    - refs: https://github.com/developit/unfetch/issues/46, https://github.com/developit/unfetch/issues/46#issuecomment-310682421
- As a workaround implements `unfetch.bind(window)`, then use the `window.fetch` if exists fetch in window. 
- Always use polyfill of unfetch because  any compiler change context of self in [polyfill.mjs#L2](https://github.com/developit/unfetch/blob/master/polyfill/polyfill.mjs#L2)
- If append the code as `unfetch.bind(window)` then `self` become the window object.
    - so using `window.fetch` in the modern browser.

## 2.  TypeError: Failed to execute 'fetch' on 'Window': Request with GET/HEAD method cannot have body.

![TypeError: Failed to execute 'fetch' on 'Window': Request with GET/HEAD method cannot have body](https://user-images.githubusercontent.com/9594376/68755281-94face00-064b-11ea-83c7-42a9c1abecff.png)

- Thrown exception in browser using `window.fetch` in the `@specter/client/lib/browser`
- Before always using the polyfill in unfetch but now (after applying this patch) using `window.fetch` in the modern browser.
- The unfetch is able to set a body, but `window.fetch` is **NOT** able to set a body.
   - So thrown exception only modern browser.