### PR TITLE
Inject default header from constructor for X-CSRF-Token

### DIFF
--- a/packages/client/__tests__/client.test.ts
+++ b/packages/client/__tests__/client.test.ts
@@ -1,7 +1,7 @@
-import Todo, { task } from "../../specter/__tests__/fixtures/Todo";
+import Todo from "../../specter/__tests__/fixtures/Todo";
 import getPort from "../../specter/__tests__/lib/getPort";
 import createApp from "../../specter/__tests__/lib/createApp";
-import Client, { Request, Response } from "../src/browser";
+import Client, { Request } from "../src/browser";
 import assert from "assert";
 
 test("Todo create by browser", async () => {
@@ -9,7 +9,7 @@ test("Todo create by browser", async () => {
   const { port } = await getPort(server);
   const client = new Client({
     base: `http://localhost:${port}/xhr`,
-    fetchOptions: {}
+    fetchOptions: {},
   });
   const request = new Request("todo", {
     headers: {},
@@ -18,9 +18,9 @@ test("Todo create by browser", async () => {
       task: {
         title: "foo",
         desc: "bar",
-        done: false
-      }
-    }
+        done: false,
+      },
+    },
   });
   const res = await client.create(request);
   const data = res.body;
@@ -29,8 +29,36 @@ test("Todo create by browser", async () => {
     task: {
       title: "foo",
       desc: "bar",
-      done: false
-    }
+      done: false,
+    },
   });
+  server.close();
+});
+
+test("client with default header", async () => {
+  const { server } = createApp(new Todo());
+  const { port } = await getPort(server);
+  const client = new Client({
+    base: `http://localhost:${port}/xhr`,
+    fetchOptions: {
+      headers: {
+        "XCSRF-Token": "EXAMPLE_TOKEN_FOR_TEST",
+      },
+    },
+  });
+  const request = new Request("todo", {
+    headers: {
+      Authorization: "Bearer xxxxxxxxxx",
+    },
+    query: {},
+    body: {
+      task: {
+        title: "foo",
+        desc: "bar",
+        done: false,
+      },
+    },
+  });
+  const res = await client.create(request);
   server.close();
 });

--- a/packages/client/lib/browser/client.d.ts
+++ b/packages/client/lib/browser/client.d.ts
@@ -4,10 +4,14 @@ declare type DefaultRequest = SpecterRequest<any, any, any>;
 declare type DefaultResponse = SpecterResponse<any, any>;
 export default class SpecterClient {
     base: string;
-    fetchOptions: object;
+    fetchOptions: {
+        headers?: Record<string, string>;
+    } & Record<string, any>;
     constructor(options: {
         base: string;
-        fetchOptions: object;
+        fetchOptions: {
+            headers?: Record<string, string>;
+        } & Record<string, any>;
     });
     private createPath;
     private executeRequest;

--- a/packages/client/lib/browser/client.js
+++ b/packages/client/lib/browser/client.js
@@ -46,6 +46,17 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
+        }
+    return t;
+};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -70,28 +81,29 @@ var SpecterClient = /** @class */ (function () {
     };
     SpecterClient.prototype.executeRequest = function (method, request) {
         return __awaiter(this, void 0, void 0, function () {
-            var path, body, head, response, json, h, headers, _i, _a, _b, key, value, result;
-            return __generator(this, function (_c) {
-                switch (_c.label) {
+            var path, body, _a, defaultHeaders, options, head, response, json, h, headers, _i, _b, _c, key, value, result;
+            return __generator(this, function (_d) {
+                switch (_d.label) {
                     case 0:
                         path = this.createPath(request);
                         body = request.body ? JSON.stringify(request.body) : null;
-                        head = __assign({}, request.headers);
+                        _a = this.fetchOptions, defaultHeaders = _a.headers, options = __rest(_a, ["headers"]);
+                        head = __assign(__assign({}, defaultHeaders), request.headers);
                         if (body && !head["Content-Type"]) {
                             head["Content-Type"] = DefaultContentType;
                         }
                         return [4 /*yield*/, (method === "GET" || method === "HEAD"
-                                ? fetch(path, __assign({ method: method, headers: head }, this.fetchOptions))
-                                : fetch(path, __assign({ method: method, headers: head, body: body }, this.fetchOptions)))];
+                                ? fetch(path, __assign({ method: method, headers: head }, options))
+                                : fetch(path, __assign({ method: method, headers: head, body: body }, options)))];
                     case 1:
-                        response = _c.sent();
+                        response = _d.sent();
                         return [4 /*yield*/, response.json()];
                     case 2:
-                        json = _c.sent();
+                        json = _d.sent();
                         h = response.headers;
                         headers = {};
-                        for (_i = 0, _a = h.entries(); _i < _a.length; _i++) {
-                            _b = _a[_i], key = _b[0], value = _b[1];
+                        for (_i = 0, _b = h.entries(); _i < _b.length; _i++) {
+                            _c = _b[_i], key = _c[0], value = _c[1];
                             headers[key] = value;
                         }
                         result = new response_1.default(headers, json);

--- a/packages/client/src/browser/client.ts
+++ b/packages/client/src/browser/client.ts
@@ -12,8 +12,11 @@ type DefaultResponse = SpecterResponse<any, any>;
 const DefaultContentType = "application/json; charset=utf-8";
 export default class SpecterClient {
   base: string;
-  fetchOptions: object;
-  constructor(options: { base: string; fetchOptions: object }) {
+  fetchOptions: { headers?: Record<string, string> } & Record<string, any>;
+  constructor(options: {
+    base: string;
+    fetchOptions: { headers?: Record<string, string> } & Record<string, any>;
+  }) {
     this.base = options.base;
     this.fetchOptions = options.fetchOptions;
   }
@@ -31,8 +34,10 @@ export default class SpecterClient {
   ): Promise<Res> {
     const path = this.createPath(request);
     const body = request.body ? JSON.stringify(request.body) : null;
+    const { headers: defaultHeaders, ...options } = this.fetchOptions;
     const head = {
-      ...request.headers
+      ...defaultHeaders,
+      ...request.headers,
     };
     if (body && !head["Content-Type"]) {
       head["Content-Type"] = DefaultContentType;
@@ -41,13 +46,13 @@ export default class SpecterClient {
       ? fetch(path, {
           method,
           headers: head,
-          ...this.fetchOptions
+          ...options,
         })
       : fetch(path, {
           method,
           headers: head,
           body,
-          ...this.fetchOptions
+          ...options,
         }));
 
     const json = await response.json();
@@ -101,7 +106,7 @@ export default class SpecterClient {
       method: "HEAD",
       headers: request.headers,
       body: JSON.stringify(request.body),
-      ...this.fetchOptions
+      ...this.fetchOptions,
     });
     return response.ok;
   }

--- a/packages/specter/__tests__/lib/createApp.ts
+++ b/packages/specter/__tests__/lib/createApp.ts
@@ -2,21 +2,25 @@ import Specter, { Service } from "../../src";
 import express from "express";
 import bodyParser from "body-parser";
 export default function createApp(service: Service, ...services: Service[]) {
+  Specter.registerService(service);
+  services.forEach((service) => {
     Specter.registerService(service);
-    services.forEach(service => {
-        Specter.registerService(service);
-    });
-    const app = express();
-    app.use((req, res, next) => {
-        res.header("Access-Control-Allow-Origin", "*");
-        res.header(
-            "Access-Control-Allow-Headers",
-            "Origin, X-Requested-With, Content-Type, Accept"
-        );
-        next();
-    });
-    app.use(bodyParser.json());
-    app.use("/xhr", Specter.createMiddleware({}));
-    const server = app.listen(0);
-    return { app, server };
+  });
+  const app = express();
+  app.use((req, res, next) => {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header(
+      "Access-Control-Allow-Headers",
+      "Origin, X-Requested-With, Content-Type, Accept,XCSRF-Token,Authorization"
+    );
+    next();
+  });
+  // for preflight (has cause preflight request when was append custom header)
+  app.options("*", function(_req, res) {
+    res.sendStatus(200);
+  });
+  app.use(bodyParser.json());
+  app.use("/xhr", Specter.createMiddleware({}));
+  const server = app.listen(0);
+  return { app, server };
 }


### PR DESCRIPTION
# Motivation

I want to append to the request header the `X-CSRF-Token`.
But, cant injectable header from outside.
I have to append `X-CSRF-Token` to every `Request` object If I try implements CSRF in the current state.

# About

- Modify  constructor of the `specter/browser/client`.

# Tests

I try implements a tests, but cant get request header from return value of `client.create()`.
I think `client.create()` function meybe better that return the `Response` and `Request`, but cant implements based on unfetch because unfetch response object not included request obhject.
> In the axios case : https://github.com/axios/axios#response-schema
