### PR TITLE
fix: failure get headers

### DIFF
--- a/packages/client/lib/browser/client.js
+++ b/packages/client/lib/browser/client.js
@@ -57,17 +57,6 @@ var __rest = (this && this.__rest) || function (s, e) {
         }
     return t;
 };
-var __values = (this && this.__values) || function(o) {
-    var s = typeof Symbol === "function" && Symbol.iterator, m = s && o[s], i = 0;
-    if (m) return m.call(o);
-    if (o && typeof o.length === "number") return {
-        next: function () {
-            if (o && i >= o.length) o = void 0;
-            return { value: o && o[i++], done: !o };
-        }
-    };
-    throw new TypeError(s ? "Object is not iterable." : "Symbol.iterator is not defined.");
-};
 var __read = (this && this.__read) || function (o, n) {
     var m = typeof Symbol === "function" && o[Symbol.iterator];
     if (!m) return o;
@@ -111,10 +100,9 @@ var SpecterClient = /** @class */ (function () {
     };
     SpecterClient.prototype.executeRequest = function (method, request) {
         return __awaiter(this, void 0, void 0, function () {
-            var path, body, _a, defaultHeaders, options, head, response, json, h, headers, _b, _c, _d, key, value, result;
-            var e_1, _e;
-            return __generator(this, function (_f) {
-                switch (_f.label) {
+            var path, body, _a, defaultHeaders, options, head, response, json, h, headers, result;
+            return __generator(this, function (_b) {
+                switch (_b.label) {
                     case 0:
                         path = this.createPath(request);
                         body = request.body ? JSON.stringify(request.body) : null;
@@ -127,25 +115,16 @@ var SpecterClient = /** @class */ (function () {
                                 ? fetch(path, __assign({ method: method, headers: head }, options))
                                 : fetch(path, __assign({ method: method, headers: head, body: body }, options)))];
                     case 1:
-                        response = _f.sent();
+                        response = _b.sent();
                         return [4 /*yield*/, response.json()];
                     case 2:
-                        json = _f.sent();
+                        json = _b.sent();
                         h = response.headers;
                         headers = {};
-                        try {
-                            for (_b = __values(h.entries()), _c = _b.next(); !_c.done; _c = _b.next()) {
-                                _d = __read(_c.value, 2), key = _d[0], value = _d[1];
-                                headers[key] = value;
-                            }
-                        }
-                        catch (e_1_1) { e_1 = { error: e_1_1 }; }
-                        finally {
-                            try {
-                                if (_c && !_c.done && (_e = _b.return)) _e.call(_b);
-                            }
-                            finally { if (e_1) throw e_1.error; }
-                        }
+                        h.forEach(function (tuple) {
+                            var _a = __read(tuple, 2), key = _a[0], value = _a[1];
+                            headers[key] = value;
+                        });
                         result = new response_1.default(headers, json);
                         if (!this.validateStatus(response.status)) {
                             throw new specter_1.SpecterNetworkError("validationStatus failure: " + response.statusText, response.status, response.statusText, request, result);

--- a/packages/client/lib/browser/client.js
+++ b/packages/client/lib/browser/client.js
@@ -57,6 +57,33 @@ var __rest = (this && this.__rest) || function (s, e) {
         }
     return t;
 };
+var __values = (this && this.__values) || function(o) {
+    var s = typeof Symbol === "function" && Symbol.iterator, m = s && o[s], i = 0;
+    if (m) return m.call(o);
+    if (o && typeof o.length === "number") return {
+        next: function () {
+            if (o && i >= o.length) o = void 0;
+            return { value: o && o[i++], done: !o };
+        }
+    };
+    throw new TypeError(s ? "Object is not iterable." : "Symbol.iterator is not defined.");
+};
+var __read = (this && this.__read) || function (o, n) {
+    var m = typeof Symbol === "function" && o[Symbol.iterator];
+    if (!m) return o;
+    var i = m.call(o), r, ar = [], e;
+    try {
+        while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
+    }
+    catch (error) { e = { error: error }; }
+    finally {
+        try {
+            if (r && !r.done && (m = i["return"])) m.call(i);
+        }
+        finally { if (e) throw e.error; }
+    }
+    return ar;
+};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -84,9 +111,10 @@ var SpecterClient = /** @class */ (function () {
     };
     SpecterClient.prototype.executeRequest = function (method, request) {
         return __awaiter(this, void 0, void 0, function () {
-            var path, body, _a, defaultHeaders, options, head, response, json, h, headers, _i, _b, _c, key, value, result;
-            return __generator(this, function (_d) {
-                switch (_d.label) {
+            var path, body, _a, defaultHeaders, options, head, response, json, h, headers, _b, _c, _d, key, value, result;
+            var e_1, _e;
+            return __generator(this, function (_f) {
+                switch (_f.label) {
                     case 0:
                         path = this.createPath(request);
                         body = request.body ? JSON.stringify(request.body) : null;
@@ -99,15 +127,24 @@ var SpecterClient = /** @class */ (function () {
                                 ? fetch(path, __assign({ method: method, headers: head }, options))
                                 : fetch(path, __assign({ method: method, headers: head, body: body }, options)))];
                     case 1:
-                        response = _d.sent();
+                        response = _f.sent();
                         return [4 /*yield*/, response.json()];
                     case 2:
-                        json = _d.sent();
+                        json = _f.sent();
                         h = response.headers;
                         headers = {};
-                        for (_i = 0, _b = h.entries(); _i < _b.length; _i++) {
-                            _c = _b[_i], key = _c[0], value = _c[1];
-                            headers[key] = value;
+                        try {
+                            for (_b = __values(h.entries()), _c = _b.next(); !_c.done; _c = _b.next()) {
+                                _d = __read(_c.value, 2), key = _d[0], value = _d[1];
+                                headers[key] = value;
+                            }
+                        }
+                        catch (e_1_1) { e_1 = { error: e_1_1 }; }
+                        finally {
+                            try {
+                                if (_c && !_c.done && (_e = _b.return)) _e.call(_b);
+                            }
+                            finally { if (e_1) throw e_1.error; }
                         }
                         result = new response_1.default(headers, json);
                         if (!this.validateStatus(response.status)) {

--- a/packages/client/lib/browser/client.js
+++ b/packages/client/lib/browser/client.js
@@ -84,7 +84,7 @@ var SpecterClient = /** @class */ (function () {
     };
     SpecterClient.prototype.executeRequest = function (method, request) {
         return __awaiter(this, void 0, void 0, function () {
-            var path, body, _a, defaultHeaders, options, head, response, json, h, headers, result;
+            var path, body, _a, defaultHeaders, options, head, response, json, h, entries, headers, result;
             return __generator(this, function (_b) {
                 switch (_b.label) {
                     case 0:
@@ -103,8 +103,9 @@ var SpecterClient = /** @class */ (function () {
                         return [4 /*yield*/, response.json()];
                     case 2:
                         json = _b.sent();
-                        h = response.headers;
-                        headers = [].slice.call(h.entries()).reduce(function (acc, _a) {
+                        h = response.headers.entries();
+                        entries = typeof h.next === 'function' ? Array.from(h) : [].slice.call(h);
+                        headers = entries.reduce(function (acc, _a) {
                             var _b;
                             var key = _a[0], value = _a[1];
                             return (__assign(__assign({}, acc), (_b = {}, _b[key] = value, _b)));

--- a/packages/client/lib/browser/client.js
+++ b/packages/client/lib/browser/client.js
@@ -104,10 +104,11 @@ var SpecterClient = /** @class */ (function () {
                     case 2:
                         json = _b.sent();
                         h = response.headers;
-                        headers = {};
-                        h.forEach(function (value, key) {
-                            headers[key] = value;
-                        });
+                        headers = [].slice.call(h.entries()).reduce(function (acc, _a) {
+                            var _b;
+                            var key = _a[0], value = _a[1];
+                            return (__assign(__assign({}, acc), (_b = {}, _b[key] = value, _b)));
+                        }, {});
                         result = new response_1.default(headers, json);
                         if (!this.validateStatus(response.status)) {
                             throw new specter_1.SpecterNetworkError("validationStatus failure: " + response.statusText, response.status, response.statusText, request, result);

--- a/packages/client/lib/browser/client.js
+++ b/packages/client/lib/browser/client.js
@@ -57,22 +57,6 @@ var __rest = (this && this.__rest) || function (s, e) {
         }
     return t;
 };
-var __read = (this && this.__read) || function (o, n) {
-    var m = typeof Symbol === "function" && o[Symbol.iterator];
-    if (!m) return o;
-    var i = m.call(o), r, ar = [], e;
-    try {
-        while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
-    }
-    catch (error) { e = { error: error }; }
-    finally {
-        try {
-            if (r && !r.done && (m = i["return"])) m.call(i);
-        }
-        finally { if (e) throw e.error; }
-    }
-    return ar;
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -121,8 +105,7 @@ var SpecterClient = /** @class */ (function () {
                         json = _b.sent();
                         h = response.headers;
                         headers = {};
-                        h.forEach(function (tuple) {
-                            var _a = __read(tuple, 2), key = _a[0], value = _a[1];
+                        h.forEach(function (value, key) {
                             headers[key] = value;
                         });
                         result = new response_1.default(headers, json);

--- a/packages/client/src/browser/client.ts
+++ b/packages/client/src/browser/client.ts
@@ -60,9 +60,7 @@ export default class SpecterClient {
         }));
 
     const json = await response.json();
-    const h = response.headers as Headers & {
-      entries: () => ReadonlyArray<[string, string]>;
-    };
+    const h = response.headers;
     const headers: { [key: string]: string } = {};
     for (const [key, value] of h.entries()) {
       headers[key] = value;

--- a/packages/client/src/browser/client.ts
+++ b/packages/client/src/browser/client.ts
@@ -41,7 +41,7 @@ export default class SpecterClient {
     const { headers: defaultHeaders, ...options } = this.fetchOptions;
     const head = {
       ...defaultHeaders,
-      ...request.headers
+      ...request.headers,
     };
     if (body && !head["Content-Type"]) {
       head["Content-Type"] = DefaultContentType;
@@ -50,21 +50,21 @@ export default class SpecterClient {
       ? fetch(path, {
           method,
           headers: head,
-          ...options
+          ...options,
         })
       : fetch(path, {
           method,
           headers: head,
           body,
-          ...options
+          ...options,
         }));
 
     const json = await response.json();
     const h = response.headers;
-    const headers: { [key: string]: string } = {};
-    h.forEach((value, key) => {
-      headers[key] = value;
-    });
+    const headers = [].slice.call(h.entries()).reduce((acc, [key, value]: [string, string]) => ({
+      ...acc,
+      [key]: value,
+    }), {} as Record<string, string>)
     const result = new SpecterResponse<any, any>(headers, json);
 
     if (!this.validateStatus(response.status)) {
@@ -119,7 +119,7 @@ export default class SpecterClient {
       method: "HEAD",
       headers: request.headers,
       body: JSON.stringify(request.body),
-      ...this.fetchOptions
+      ...this.fetchOptions,
     });
     return response.ok;
   }

--- a/packages/client/src/browser/client.ts
+++ b/packages/client/src/browser/client.ts
@@ -62,10 +62,9 @@ export default class SpecterClient {
     const json = await response.json();
     const h = response.headers;
     const headers: { [key: string]: string } = {};
-    h.forEach((tuple) => {
-      const [key, value] = tuple
+    h.forEach((value, key) => {
       headers[key] = value;
-    })
+    });
     const result = new SpecterResponse<any, any>(headers, json);
 
     if (!this.validateStatus(response.status)) {

--- a/packages/client/src/browser/client.ts
+++ b/packages/client/src/browser/client.ts
@@ -62,9 +62,10 @@ export default class SpecterClient {
     const json = await response.json();
     const h = response.headers;
     const headers: { [key: string]: string } = {};
-    for (const [key, value] of h.entries()) {
+    h.forEach((tuple) => {
+      const [key, value] = tuple
       headers[key] = value;
-    }
+    })
     const result = new SpecterResponse<any, any>(headers, json);
 
     if (!this.validateStatus(response.status)) {

--- a/packages/client/src/browser/client.ts
+++ b/packages/client/src/browser/client.ts
@@ -41,7 +41,7 @@ export default class SpecterClient {
     const { headers: defaultHeaders, ...options } = this.fetchOptions;
     const head = {
       ...defaultHeaders,
-      ...request.headers,
+      ...request.headers
     };
     if (body && !head["Content-Type"]) {
       head["Content-Type"] = DefaultContentType;
@@ -50,26 +50,33 @@ export default class SpecterClient {
       ? fetch(path, {
           method,
           headers: head,
-          ...options,
+          ...options
         })
       : fetch(path, {
           method,
           headers: head,
           body,
-          ...options,
+          ...options
         }));
 
     const json = await response.json();
-    const h = response.headers.entries() as IterableIterator<[string, string]> | Array<[string, string]>;
-    // @ts-ignore
-    // CAUTION: 
+    const h = response.headers.entries() as
+      | IterableIterator<[string, string]>
+      | Array<[string, string]>;
+    // CAUTION:
     // This type guard is not complete, but do not want to inject polyfill of `Symbol`,
     // so whether Array or Iterator decide by next() method.
-    const entries = typeof h.next === 'function' ? Array.from(h) : [].slice.call(h)
-    const headers = entries.reduce((acc, [key, value]: [string, string]) => ({
-      ...acc,
-      [key]: value,
-    }), {} as Record<string, string>)
+    const entries =
+      /* eslint @typescript-eslint/ban-ts-ignore: [0] */
+      // @ts-ignore
+      typeof h.next === "function" ? Array.from(h) : [].slice.call(h);
+    const headers = entries.reduce(
+      (acc, [key, value]: [string, string]) => ({
+        ...acc,
+        [key]: value
+      }),
+      {} as Record<string, string>
+    );
     const result = new SpecterResponse<any, any>(headers, json);
 
     if (!this.validateStatus(response.status)) {
@@ -124,7 +131,7 @@ export default class SpecterClient {
       method: "HEAD",
       headers: request.headers,
       body: JSON.stringify(request.body),
-      ...this.fetchOptions,
+      ...this.fetchOptions
     });
     return response.ok;
   }

--- a/packages/client/src/browser/client.ts
+++ b/packages/client/src/browser/client.ts
@@ -60,8 +60,13 @@ export default class SpecterClient {
         }));
 
     const json = await response.json();
-    const h = response.headers;
-    const headers = [].slice.call(h.entries()).reduce((acc, [key, value]: [string, string]) => ({
+    const h = response.headers.entries() as IterableIterator<[string, string]> | Array<[string, string]>;
+    // @ts-ignore
+    // CAUTION: 
+    // This type guard is not complete, but do not want to inject polyfill of `Symbol`,
+    // so whether Array or Iterator decide by next() method.
+    const entries = typeof h.next === 'function' ? Array.from(h) : [].slice.call(h)
+    const headers = entries.reduce((acc, [key, value]: [string, string]) => ({
       ...acc,
       [key]: value,
     }), {} as Record<string, string>)

--- a/packages/client/src/browser/tsconfig.json
+++ b/packages/client/src/browser/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "target": "es5",
-    "outDir": "../../lib/"
-  }
-}

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "es5",
+    "lib": ["ES2015","dom","DOM.Iterable"],
     "outDir": "./lib"
   },
   "include": ["./src"]

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "es5",
+    "downlevelIteration": true,
     "outDir": "./lib"
   },
   "include": ["./src"]

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "es5",
-    "downlevelIteration": true,
     "outDir": "./lib"
   },
   "include": ["./src"]

--- a/packages/specter/lib/response.js
+++ b/packages/specter/lib/response.js
@@ -11,7 +11,7 @@ class SpecterResponse {
     setNextReqs(...reqs) {
         this.headers = {
             ...this.headers,
-            "x-specter-next-reqs": reqs.map((req) => req.toString()).join("__sep__"),
+            "x-specter-next-reqs": reqs.map(req => req.toString()).join("__sep__")
         };
         this.nextReqs = reqs;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
     /* Basic Options */
     "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    "lib": ["ES2015", "DOM", "DOM.Iterable"],                             /* Specify library files to be included in the compilation. */
-    "downlevelIteration": true,
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     /* Basic Options */
     "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["ES2015", "DOM", "DOM.Iterable"],                             /* Specify library files to be included in the compilation. */
+    "downlevelIteration": true,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
# About
`specter` did cast of headers to `ReadonlyArray<[string, string]>`.
Along, TypeScript transpiled array style `for-loop` when casted to Array.
`specter` should not cast a headers object.
