### PR TITLE
[redux-effects-specter-cache] [Feature] Replace Storage

### DIFF
--- a/packages/redux-effects-specter-cache/README.md
+++ b/packages/redux-effects-specter-cache/README.md
@@ -7,6 +7,7 @@ Caching middleware for
 
 ```
 npm install --save @specter/specter  \                  # peer dependency
+                   @specter/storage \                   # peer dependency
                    @specter/redux-effects-specter \     # peer dependency
                    @specter/redux-effects-specter-cache
 ```

--- a/packages/redux-effects-specter-cache/lib/index.d.ts
+++ b/packages/redux-effects-specter-cache/lib/index.d.ts
@@ -1,5 +1,4 @@
 import { Middleware } from "redux";
-import LRUCache from "lru-cache";
 import { SPECTER, Payload } from "@specter/redux-effects-specter";
 declare type SpecterAction = {
     type: typeof SPECTER;
@@ -19,6 +18,6 @@ export declare type MiddlewareOption<S> = {
 export declare function resetCacheData(): void;
 export default function reduxEffectsSpecterCache<S = any>({ middlewareOption, cacheOption }: {
     middlewareOption?: MiddlewareOption<S>;
-    cacheOption?: LRUCache.Options<string, Record<string, any>>;
+    cacheOption?: Record<string, any>;
 }): Middleware;
 export {};

--- a/packages/redux-effects-specter-cache/lib/index.js
+++ b/packages/redux-effects-specter-cache/lib/index.js
@@ -1,22 +1,19 @@
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-var lru_cache_1 = __importDefault(require("lru-cache"));
+var storage_1 = require("@specter/storage");
 var redux_effects_specter_1 = require("@specter/redux-effects-specter");
 var cacheInstance = null;
 function createCache(cacheOption) {
     if (cacheInstance !== null)
         return cacheInstance;
-    cacheInstance = new lru_cache_1.default(cacheOption);
+    cacheInstance = new storage_1.LRUCache(cacheOption);
     return cacheInstance;
 }
 // CAUTION: this function expected to call after the createCache execudes in once.
 // MEMO: this can call from outside middleware, and reset a cache data.
 function resetCacheData() {
     var cache = createCache();
-    cache.reset();
+    cache.clearAll();
 }
 exports.resetCacheData = resetCacheData;
 function reduxEffectsSpecterCache(_a) {
@@ -53,7 +50,7 @@ function reduxEffectsSpecterCache(_a) {
             return next(action).then(function (resp) {
                 var manualCache = toCache && toCache(action, getState());
                 if (!toCache || manualCache) {
-                    cache.set(cacheKey, resp);
+                    cache.put(cacheKey, resp);
                 }
                 return resp;
             });

--- a/packages/redux-effects-specter-cache/package-lock.json
+++ b/packages/redux-effects-specter-cache/package-lock.json
@@ -604,6 +604,22 @@
         "type-detect": "4.0.8"
       }
     },
+    "@specter/redux-effects-specter": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@specter/redux-effects-specter/-/redux-effects-specter-0.2.2.tgz",
+      "integrity": "sha512-irS87tKMpEvT91QXTyh9HFT0qEOCB6SVKq3SCpcTG2KbzrJMDZouyRC3VOXF1WRpJ0FtXCRK50yYZDHeCcgsdA==",
+      "dev": true
+    },
+    "@specter/specter": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@specter/specter/-/specter-0.2.2.tgz",
+      "integrity": "sha512-jDaC6BZM2zt9y/4icI2zk/bWA0T9BWyyjeKCAC6/sL7Xom2Befu8BKdqUJiWN2eeuP9Hx+2l4yYItQ40RCiDzQ==",
+      "dev": true,
+      "requires": {
+        "@types/express": "4.17.1",
+        "unfetch": "^4.1.0"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
@@ -645,11 +661,52 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
+    },
+    "@types/connect": {
+      "version": "3.4.33",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
+      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
+      "integrity": "sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
@@ -681,6 +738,18 @@
       "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
       "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
     },
+    "@types/mime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
+      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "13.13.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
+      "integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
+      "dev": true
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -693,12 +762,34 @@
       "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
       "dev": true
     },
+    "@types/qs": {
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.2.tgz",
+      "integrity": "sha512-a9bDi4Z3zCZf4Lv1X/vwnvbbDYSNz59h3i3KdyuYYN+YrLjSeJD0dnphdULDfySvUv6Exy/O0K6wX/kQpnPQ+A==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+      "dev": true
+    },
     "@types/redux": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@types/redux/-/redux-3.6.0.tgz",
       "integrity": "sha1-8evh5UEVGAcuT9/KXHbhbnTBOZo=",
       "requires": {
         "redux": "*"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
+      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
       }
     },
     "@types/stack-utils": {
@@ -2938,14 +3029,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "requires": {
-        "yallist": "^3.0.2"
-      }
-    },
     "make-dir": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
@@ -4451,6 +4534,12 @@
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
+    "unfetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.1.0.tgz",
+      "integrity": "sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==",
+      "dev": true
+    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -4704,11 +4793,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
-    },
-    "yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
       "version": "15.3.1",

--- a/packages/redux-effects-specter-cache/package.json
+++ b/packages/redux-effects-specter-cache/package.json
@@ -33,20 +33,18 @@
   },
   "dependencies": {
     "@types/lru-cache": "^5.1.0",
-    "@types/redux": "^3.6.0",
-    "lru-cache": "^5.1.1"
+    "@types/redux": "^3.6.0"
   },
   "devDependencies": {
     "@specter/redux-effects-specter": "^0.2.2",
     "@specter/specter": "^0.2.2",
+    "@specter/storage": "^0.2.2",
     "jest": "25.4.0",
     "redux": "4.0.5",
     "ts-jest": "25.4.0",
     "typescript": "3.8.3"
   },
   "peerDependencies": {
-    "@specter/redux-effects-specter": "0.0.25",
-    "@specter/specter": "0.0.25",
     "redux": ">= 4.0"
   },
   "gitHead": "ed3816e0cb5862fc1c87ccea4af501debe5d94a6",


### PR DESCRIPTION
# Motivation
- [node-lru-cache](https://github.com/isaacs/node-lru-cache) is required to transpile in using in E11.
- Dependencies is better inside than outside.