### PR TITLE
fix: Keep headears including X-Specter-Method

### DIFF
--- a/packages/client/__tests__/client.test.ts
+++ b/packages/client/__tests__/client.test.ts
@@ -143,3 +143,65 @@ test("Todo create and update and delete with fallback by browser", async () => {
   assert.deepEqual(data, { id: 0 });
   server.close();
 });
+
+test("Todo create and update and delete with fallback and default header by browser", async () => {
+  const { server } = createApp(new Todo());
+  const { port } = await getPort(server);
+  const client = new Client({
+    base: `http://localhost:${port}/xhr`,
+    fetchOptions: {
+      headers: {
+        "XCSRF-Token": "EXAMPLE_TOKEN_FOR_TEST",
+      },
+    },
+    fallbackMethod: "POST",
+  });
+  const request = new Request("todo", {
+    headers: {},
+    query: {},
+    body: {
+      task: {
+        title: "foo",
+        desc: "bar",
+        done: false,
+      },
+    },
+  });
+  let res = await client.create(request);
+  let data = res.body;
+  assert.deepStrictEqual(data, {
+    id: 0,
+    task: {
+      title: "foo",
+      desc: "bar",
+      done: false,
+    },
+  });
+  request.query = {
+    id: data.id,
+  };
+  request.body = {
+    task: {
+      title: "foo",
+      desc: "bar",
+      done: true,
+    },
+  };
+  res = await client.update(request);
+  data = res.body;
+  assert.deepEqual(data, {
+    id: 0,
+    task: {
+      title: "foo",
+      desc: "bar",
+      done: true,
+    },
+  });
+  res = await client.delete(request);
+  data = res.body;
+  assert.deepEqual(data, {});
+  res = await client.read(request);
+  data = res.body;
+  assert.deepEqual(data, { id: 0 });
+  server.close();
+});

--- a/packages/client/src/browser/client.ts
+++ b/packages/client/src/browser/client.ts
@@ -43,7 +43,8 @@ export default class SpecterClient {
     const path = this.createPath(request);
     const body = request.body ? JSON.stringify(request.body) : null;
     const defaultHeaders = this.fetchOptions?.headers;
-    const options = this.fetchOptions;
+    const options = { ...this.fetchOptions };
+    delete options["headers"];
     const head = {
       ...defaultHeaders,
       ...request.headers,


### PR DESCRIPTION
I found a bug related to `fallbackMethod` and `fetchOptions.headers` .

```ts
  const client = new Client({
    base: '/xhr',
    fetchOptions: {
      headers: {
        'CSRF-Token': some_token_vallue,
      }
    },
    fallbackMethod: 'POST', 
  })
```

The `client.delete` ( or `.update`) invoke not `Service#delete` but `Service#create` method because the headers object ( `{   'CSRF-Token': some_token_vallue }`) overrides the original specter client's header whose has `X-Specer-Method` key.