### PR TITLE
add ./lib/* to the endpoint of exports

### DIFF
--- a/packages/specter/package.json
+++ b/packages/specter/package.json
@@ -13,6 +13,10 @@
       "require": "./lib/index.js",
       "import": "./esm/index.js"
     },
+    "./lib/*": {
+      "require": "./lib/index.js",
+      "import": "./esm/index.js"
+    },
     "./browser": {
       "require": "./lib/browser/index.js",
       "import": "./esm/browser/index.js"


### PR DESCRIPTION
When I updated next.js to v11 for a project that uses specter, I got the following error.

```json
error - ./node_modules/@specter/client/lib/browser/response.js:4:0
Module not found: Package path ./lib/request is not exported from package /Users/my-project/node_modules/@specter/specter (see exports field in /Users/my-project/node_modules/@specter/specter/package.json)
```

It seemed to be because the ./lib/* was not exported, so I added it to the package.json "exports" field .
